### PR TITLE
refactor to improve the functional paradigm

### DIFF
--- a/06-to_production/1-from_localstack_to_aws/src/app/scripts/configure-eventbridge_sqs.ts
+++ b/06-to_production/1-from_localstack_to_aws/src/app/scripts/configure-eventbridge_sqs.ts
@@ -116,13 +116,8 @@ async function createTarget(target: TargetConfig): Promise<void> {
 }
 
 function extractRulesFromQueues(queues: QueueConfig[], eventBusName: string): RuleConfig[] {
-	const uniquePatterns = new Set<string>();
-
-	queues.forEach((queue) => {
-		queue.rulePattern.forEach((pattern) => {
-			uniquePatterns.add(pattern);
-		});
-	});
+	const patterns = queues.flatMap((queue) => queue.rulePattern)
+	const uniquePatterns = new Set<string>(patterns);
 
 	return Array.from(uniquePatterns).map((pattern) => ({
 		name: formatRuleName(pattern),
@@ -132,28 +127,23 @@ function extractRulesFromQueues(queues: QueueConfig[], eventBusName: string): Ru
 }
 
 function extractTargetsFromQueues(queues: QueueConfig[], eventBusName: string): TargetConfig[] {
-	const targetsMap: Map<string, TargetConfig> = new Map();
-
-	queues.forEach((queue) => {
-		queue.rulePattern.forEach((pattern) => {
+	const targetsMap = queues.reduce((targetsMap, queue) => {
+		return queue.rulePattern.reduce((targetsMap, pattern) => {
 			const ruleName = formatRuleName(pattern);
-			if (!targetsMap.has(ruleName)) {
-				targetsMap.set(ruleName, {
+			if (!targetsMap[ruleName])) {
+				targetsMap[ruleName] = {
 					eventBusName,
 					ruleName,
 					queueName: [queue.name],
-				});
+				};
 			} else {
-				const target = targetsMap.get(ruleName);
-
-				if (target) {
-					target.queueName.push(queue.name);
-				}
+				targetsMap[ruleName].queueName.push(queue.name);
 			}
-		});
-	});
-
-	return Array.from(targetsMap.values());
+			return targetsMap;
+		}, targetsMap);
+	}, {} as Record<string, TargetConfig>);
+	
+	return Object.values(targetsMap);
 }
 
 function formatRuleName(rulePattern: string): string {


### PR DESCRIPTION
Personalmente creo que forEach no debería usarse en ningún caso para modificar variables ya que se podría usar reduce en su lugar

La función extractRulesFromQueues queda mucho más legible evitando bucles anidados y efectos laterales. 

La función extractTargetsFromQueues puede que a primera vista no parezca más legible para quien no está acostumbrado a trabajar con reduces pero evita efectos laterales de modificar variables de fuera de su scope... Además cambie map por record ya que aun que sea menos eficiente typescript trabaja mejor con esa estructura evitando ifs innecesarios.